### PR TITLE
L2ガスリミットを変数に変更

### DIFF
--- a/packages/contracts-bedrock/scripts/oasys/L1/build/Build.s.sol
+++ b/packages/contracts-bedrock/scripts/oasys/L1/build/Build.s.sol
@@ -172,6 +172,7 @@ contract Build is Script {
         uint256 l2ChainId = vm.envUint("L2_CHAIN_ID");
         uint256 l1BlockTime = vm.envUint("L1_BLOCK_TIME");
         uint256 l2BlockTime = vm.envUint("L2_BLOCK_TIME");
+        uint256 l2GasLimit = vm.envUint("L2_GAS_LIMIT");
         uint256 finalizationPeriodSeconds = vm.envUint("FINALIZATION_PERIOD_SECONDS");
         uint256 l2ZeroFeeTime = vm.envOr("ENABLE_L2_ZERO_FEE", false) ? block.timestamp : 0;
 
@@ -223,7 +224,7 @@ contract Build is Script {
             governanceTokenName: "Optimism",
             governanceTokenOwner: finalSystemOwner,
             // ----
-            l2GenesisBlockGasLimit: 30_000_000,
+            l2GenesisBlockGasLimit: l2GasLimit,
             l2GenesisBlockBaseFeePerGas: 0, // TODO: gasless
             l2GenesisRegolithTimeOffset: 0,
             // ----
@@ -253,6 +254,7 @@ contract Build is Script {
             l2OutputOracleChallenger: deployCfg.l2OutputOracleChallenger,
             batchSenderAddress: deployCfg.batchSenderAddress,
             l2BlockTime: deployCfg.l2BlockTime,
+            l2GasLimit: uint64(deployCfg.l2GenesisBlockGasLimit),
             l2OutputOracleSubmissionInterval: deployCfg.l2OutputOracleSubmissionInterval,
             finalizationPeriodSeconds: deployCfg.finalizationPeriodSeconds,
             l2OutputOracleStartingBlockNumber: deployCfg.l2OutputOracleStartingBlockNumber,

--- a/packages/contracts-bedrock/src/oasys/L1/build/L1BuildAgent.sol
+++ b/packages/contracts-bedrock/src/oasys/L1/build/L1BuildAgent.sol
@@ -299,10 +299,16 @@ contract L1BuildAgent is IL1BuildAgent, ISemver {
                 // This is originally `p2pSequencerAddress` which sign the block for p2p propagation
                 // Don't distinguish between sequencer and p2pSequencerAddress(=unsafeBlockSigner)
                 _unsafeBlockSigner: _cfg.l2OutputOracleProposer,
-                // Same as the OP Mainnet
-                _overhead: 188, // gasPriceOracleOverhead / TODO: Parametrize?
-                _scalar: 684_000, // gasPriceOracleScalar / TODO: Parametrize?
-                _gasLimit: 30_000_000 // l2GenesisBlockGasLimit / TODO: Parametrize?
+                // gasPriceOracleOverhead
+                // The rollup gas of L2 txs batch is calculated by the size of L2 data. This overhead is added to it.
+                // The value bellow is the same as the value of the Opstack Mainnet
+                _overhead: 188,
+                // gasPriceOracleScalar
+                // This scalar multiply the rollup gas of L2 txs batch. right after, the result is devided by 1_000_000
+                // As a result, the gas is 684_000/1_000_000 of comupted value. unknown why this is needed.
+                // The value bellow is the same as the value of the Opstack Mainnet
+                _scalar: 684_000,
+                _gasLimit: _cfg.l2GasLimit
              })
         });
     }

--- a/packages/contracts-bedrock/src/oasys/L1/build/interfaces/IL1BuildAgent.sol
+++ b/packages/contracts-bedrock/src/oasys/L1/build/interfaces/IL1BuildAgent.sol
@@ -18,6 +18,10 @@ interface IL1BuildAgent {
         // the block time of l2 chain
         // Value: 2s
         uint256 l2BlockTime;
+        // the gas limit of l2 chain
+        // This value is stored on L1 SystemConfig contract, then referred by op-node to set the gas limit of l2 block.
+        // Value: 30000000
+        uint64 l2GasLimit;
         // Used for calculate the next checkpoint block number, in Opstack case, 120 is set in testnet. 2s(default l2
         // block time) * 120 = 240s. submit l2 root every 240s. it means l2->l1 withdrawal will be available every 240s.
         // Value: 120


### PR DESCRIPTION
L2ガスリミットはL1にデプロイされたSystemConfigの値を参照していた。
なので、ここを固定値ではなく、環境変数から指定できるように変数に変更した。