### PR TITLE
Remove ZeroFee code to resolve recurring conflicts

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -562,9 +562,6 @@ type L2CoreDeployConfig struct {
 	// from. It is an override to set this value on legacy networks where it is not set by
 	// default. It can be removed once all networks have this value set in their storage.
 	SystemConfigStartBlock uint64 `json:"systemConfigStartBlock"`
-
-	// The timestamp for enabling the L2 zero-fee mode.
-	L2ZeroFeeTime *uint64 `json:"l2ZeroFeeTime,omitempty"`
 }
 
 var _ ConfigChecker = (*L2CoreDeployConfig)(nil)

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -40,11 +40,6 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 		eip1559Elasticity = 10
 	}
 
-	var zeroFeeTimes []uint64
-	if config.L2ZeroFeeTime != nil {
-		zeroFeeTimes = append(zeroFeeTimes, *config.L2ZeroFeeTime)
-	}
-
 	l1StartTime := l1StartHeader.Time
 
 	optimismChainConfig := params.ChainConfig{
@@ -77,7 +72,6 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 		GraniteTime:                   config.GraniteTime(l1StartTime),
 		HoloceneTime:                  config.HoloceneTime(l1StartTime),
 		InteropTime:                   config.InteropTime(l1StartTime),
-		ZeroFeeTimes:                  zeroFeeTimes,
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,
 			EIP1559Elasticity:        eip1559Elasticity,


### PR DESCRIPTION
OP公式のgenesis.json生成機能を利用することは無くなるので今後のコンフリクトを避けるためOasys独自コードを削除しました