### PR TITLE
Skip l2 genesis check to support ancient pruned node

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -443,6 +443,14 @@ var (
 		Category: RollupCategory,
 		Hidden:   true,
 	}
+	/* Oasys flags. */
+	SkipL2GenesisBlockHashCheck = &cli.BoolFlag{
+		Name:     "skip-l2-genesis-block-hash-check",
+		Usage:    "Skip checking the L2 genesis block hash. Must be true for ancient pruned chains.",
+		EnvVars:  prefixEnvVars("SKIP_L2_GENESIS_BLOCK_HASH_CHECK"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -498,6 +506,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCPort,
 	InteropJWTSecret,
 	IgnoreMissingPectraBlobSchedule,
+	SkipL2GenesisBlockHashCheck,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -397,7 +397,9 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to create Engine client: %w", err)
 	}
 
-	if err := cfg.Rollup.ValidateL2Config(ctx, n.l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
+	skipL2GenesisBlockHash := cfg.Sync.SyncMode == sync.ELSync || cfg.Sync.SkipL2GenesisBlockHashCheck
+	n.log.Info("Skip L2 genesis block hash check", "skipL2GenesisBlockHashCheck", cfg.Sync.SkipL2GenesisBlockHashCheck, "syncMode", cfg.Sync.SyncMode)
+	if err := cfg.Rollup.ValidateL2Config(ctx, n.l2Source, skipL2GenesisBlockHash); err != nil {
 		return err
 	}
 

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -72,4 +72,7 @@ type Config struct {
 	SkipSyncStartCheck bool `json:"skip_sync_start_check"`
 
 	SupportsPostFinalizationELSync bool `json:"supports_post_finalization_elsync"`
+
+	// SkipL2GenesisBlockHashCheck skip checking the L2 genesis block hash. Must be true for ancient pruned chains. Default is false.
+	SkipL2GenesisBlockHashCheck bool `json:"skip_l2_genesis_block_hash_check"`
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -300,6 +300,7 @@ func NewSyncConfig(ctx *cli.Context, log log.Logger) (*sync.Config, error) {
 		SyncMode:                       mode,
 		SkipSyncStartCheck:             ctx.Bool(flags.SkipSyncStartCheck.Name),
 		SupportsPostFinalizationELSync: engineKind.SupportsPostFinalizationELSync(),
+		SkipL2GenesisBlockHashCheck:    ctx.Bool(flags.SkipL2GenesisBlockHashCheck.Name),
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync


### PR DESCRIPTION
Ancient PruneしてもGenesisブロックはPruneされない。
が、L2 UpgradeしたNodeの最初のL2ブロックはPruneされる。
op-nodeの起動時にこのPruneしたブロックを参照しているので、以下のようなエラーがでる。
```
t=2025-11-05T08:11:28+0000 lvl=error msg="Error initializing the rollup node" err="failed to init L2: failed to get L2 genesis blockhash: failed to determine L2BlockRef of height 7564846, could not get payload: not found"
t=2025-11-05T08:11:28+0000 lvl=crit msg="Application failed" message="failed to setup: unable to create the rollup node: failed to init L2: failed to get L2 genesis blockhash: failed to determine L2BlockRef of height 7564846, could not get payload: not found"
```
これを迂回するためのフラグを実装。